### PR TITLE
:bookmark: bump version 0.2.1 -> 0.3.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.18
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.2.1
+current_version: 0.3.0
 django_versions:
 - '4.2'
 - '5.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.3.0]
+
 ### Changed
 
 -   Now using v2024.18 of `django-twc-package`.
@@ -76,7 +78,8 @@ Initial release!
 
 -   Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/westerveltco/django-q-registry/compare/v0.2.1...HEAD
+[unreleased]: https://github.com/westerveltco/django-q-registry/compare/v0.3.0...HEAD
 [0.1.0]: https://github.com/westerveltco/django-q-registry/releases/tag/v0.1.0
 [0.2.0]: https://github.com/westerveltco/django-q-registry/releases/tag/v0.2.0
 [0.2.1]: https://github.com/westerveltco/django-q-registry/releases/tag/v0.2.1
+[0.3.0]: https://github.com/westerveltco/django-q-registry/releases/tag/v0.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ Source = "https://github.com/westerveltco/django-q-registry"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.2.1"
+current_version = "0.3.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_q_registry/__init__.py
+++ b/src/django_q_registry/__init__.py
@@ -6,4 +6,4 @@ __all__ = [
     "register_task",
 ]
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_q_registry import __version__
 
 
 def test_version():
-    assert __version__ == "0.2.1"
+    assert __version__ == "0.3.0"


### PR DESCRIPTION
- `6c81796`: bump template to v2024.17 (#27)
- `59c7329`: [pre-commit.ci] pre-commit autoupdate (#26)
- `77984f0`: [pre-commit.ci] pre-commit autoupdate (#28)
- `dffbbb7`: [pre-commit.ci] pre-commit autoupdate (#29)
- `e6502c2`: drop support for Django 3.2 (#32)
- `c673b84`: bump template to v2024.18 (#31)