### PR TITLE
:bookmark: bump version 0.3.2 -> 0.4.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.24
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.3.2
+current_version: 0.4.0
 django_versions:
 - '4.2'
 - '5.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.4.0]
+
 ### Added
 
 - Support for Python 3.13.
@@ -99,10 +101,11 @@ Initial release!
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/westerveltco/django-q-registry/compare/v0.3.2...HEAD
+[unreleased]: https://github.com/westerveltco/django-q-registry/compare/v0.4.0...HEAD
 [0.1.0]: https://github.com/westerveltco/django-q-registry/releases/tag/v0.1.0
 [0.2.0]: https://github.com/westerveltco/django-q-registry/releases/tag/v0.2.0
 [0.2.1]: https://github.com/westerveltco/django-q-registry/releases/tag/v0.2.1
 [0.3.0]: https://github.com/westerveltco/django-q-registry/releases/tag/v0.3.0
 [0.3.1]: https://github.com/westerveltco/django-q-registry/releases/tag/v0.3.1
 [0.3.2]: https://github.com/westerveltco/django-q-registry/releases/tag/v0.3.2
+[0.4.0]: https://github.com/westerveltco/django-q-registry/releases/tag/v0.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ Source = "https://github.com/westerveltco/django-q-registry"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.3.2"
+current_version = "0.4.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_q_registry/__init__.py
+++ b/src/django_q_registry/__init__.py
@@ -6,4 +6,4 @@ __all__ = [
     "register_task",
 ]
 
-__version__ = "0.3.2"
+__version__ = "0.4.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_q_registry import __version__
 
 
 def test_version():
-    assert __version__ == "0.3.2"
+    assert __version__ == "0.4.0"


### PR DESCRIPTION
- `7ea2308`: [pre-commit.ci] pre-commit autoupdate (#42)
- `59ae529`: [pre-commit.ci] pre-commit autoupdate (#43)
- `c6ff3da`: [pre-commit.ci] pre-commit autoupdate (#44)
- `afab0c8`: [pre-commit.ci] pre-commit autoupdate (#45)
- `2345d20`: :robot: :arrow_up: [pre-commit.ci] pre-commit autoupdate (#46)
- `4926402`: [pre-commit.ci] pre-commit autoupdate (#47)
- `ab4e1e8`: [pre-commit.ci] pre-commit autoupdate (#48)
- `358cc9b`: [pre-commit.ci] pre-commit autoupdate (#49)
- `1539962`: [pre-commit.ci] pre-commit autoupdate (#50)
- `cc90ef8`: [pre-commit.ci] pre-commit autoupdate (#51)
- `a5bb5c3`: bump template to 2024.24 (#52)