### PR TITLE
:pencil: Spacing changes for docs project

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,19 @@ A Django app to register periodic Django Q tasks.
 
 1. Install the package from PyPI:
 
-```bash
-python -m pip install django-q-registry
-```
+    ```bash
+    python -m pip install django-q-registry
+    ```
 
 2. Add the app to your Django project's `INSTALLED_APPS`:
 
-```python
-INSTALLED_APPS = [
-    ...,
-    "django_q_registry",
-    ...,
-]
-```
+    ```python
+    INSTALLED_APPS = [
+        ...,
+        "django_q_registry",
+        ...,
+    ]
+    ```
 
 ## Getting Started
 
@@ -42,77 +42,77 @@ There are three supported ways to register periodic tasks:
 
 1. In a `tasks.py` file in a Django app, using the `@register_task` decorator:
 
-   ```python
-   # tasks.py
-   from django.core.mail import send_mail
-   from django_q.models import Schedule
-   from django_q_registry import register_task
+    ```python
+    # tasks.py
+    from django.core.mail import send_mail
+    from django_q.models import Schedule
+    from django_q_registry import register_task
 
 
-   @register_task(
-       name="Send periodic test email",
-       schedule_type=Schedule.CRON,
-       # https://crontab.guru/#*/5_*_*_*_*
-       cron="*/5 * * * *",
-   )
-   def send_test_email():
-       send_mail(
-           subject="Test email",
-           message="This is a test email.",
-           from_email="noreply@example.com",
-           recipient_list=["johndoe@example.com"],
-       )
-   ```
+    @register_task(
+        name="Send periodic test email",
+        schedule_type=Schedule.CRON,
+        # https://crontab.guru/#*/5_*_*_*_*
+        cron="*/5 * * * *",
+    )
+    def send_test_email():
+        send_mail(
+            subject="Test email",
+            message="This is a test email.",
+            from_email="noreply@example.com",
+            recipient_list=["johndoe@example.com"],
+        )
+    ```
 
 2. In a `tasks.py` file in a Django app, using the `registry.register` function directly:
 
-   ```python
-   # tasks.py
-   from django.core.mail import send_mail
-   from django_q.models import Schedule
-   from django_q_registry.registry import registry
+    ```python
+    # tasks.py
+    from django.core.mail import send_mail
+    from django_q.models import Schedule
+    from django_q_registry.registry import registry
 
 
-   registry.register(
-       send_mail,
-       name="Send periodic test email",
-       kwargs={
-           "subject": "Test email",
-           "message": "This is a test email.",
-           "from_email": "noreply@example.com",
-           "recipient_list": ["janedoe@example.com"],
-       },
-       schedule_type=Schedule.CRON,
-       # https://crontab.guru/#*/5_*_*_*_*
-       cron="*/5 * * * *",
-   )
-   ```
+    registry.register(
+        send_mail,
+        name="Send periodic test email",
+        kwargs={
+            "subject": "Test email",
+            "message": "This is a test email.",
+            "from_email": "noreply@example.com",
+            "recipient_list": ["janedoe@example.com"],
+        },
+        schedule_type=Schedule.CRON,
+        # https://crontab.guru/#*/5_*_*_*_*
+        cron="*/5 * * * *",
+    )
+    ```
 
 3. In a Django project's `settings.py` file, using the `Q_REGISTRY["TASKS"]` setting:
 
-   ```python
-   # settings.py
-   from django_q.models import Schedule
+    ```python
+    # settings.py
+    from django_q.models import Schedule
 
 
-   Q_REGISTRY = {
-       "TASKS": [
-           {
-               "name": "Send periodic test email",
-               "func": "django.core.mail.send_mail",
-               "kwargs": {
-                   "subject": "Test email",
-                   "message": "This is a test email.",
-                   "from_email": "noreply@example.com",
-                   "recipient_list": ["janedoe@example.com"],
-               },
-               "schedule_type": Schedule.CRON,
-               # https://crontab.guru/#*/5_*_*_*_*
-               "cron": "*/5 * * * *",
-           },
-       ],
-   }
-   ```
+    Q_REGISTRY = {
+        "TASKS": [
+            {
+                "name": "Send periodic test email",
+                "func": "django.core.mail.send_mail",
+                "kwargs": {
+                    "subject": "Test email",
+                    "message": "This is a test email.",
+                    "from_email": "noreply@example.com",
+                    "recipient_list": ["janedoe@example.com"],
+                },
+                "schedule_type": Schedule.CRON,
+                # https://crontab.guru/#*/5_*_*_*_*
+                "cron": "*/5 * * * *",
+            },
+        ],
+    }
+    ```
 
 ### Setting up Periodic Tasks in Production
 


### PR DESCRIPTION
The editorconfig is already set to 4 spaces, so this just brings the README in line with that. This benefits mkdocs over in https://github.com/westerveltco/central-docs/