### PR TITLE
:bookmark: bump version 0.4.0 -> 0.5.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.24
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.4.0
+current_version: 0.5.0
 django_versions:
 - '4.2'
 - '5.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.5.0]
+
 ### Added
 
 - Support for Django 5.1 and 5.2.
@@ -109,7 +111,7 @@ Initial release!
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/westerveltco/django-q-registry/compare/v0.4.0...HEAD
+[unreleased]: https://github.com/westerveltco/django-q-registry/compare/v0.5.0...HEAD
 [0.1.0]: https://github.com/westerveltco/django-q-registry/releases/tag/v0.1.0
 [0.2.0]: https://github.com/westerveltco/django-q-registry/releases/tag/v0.2.0
 [0.2.1]: https://github.com/westerveltco/django-q-registry/releases/tag/v0.2.1
@@ -117,3 +119,4 @@ Initial release!
 [0.3.1]: https://github.com/westerveltco/django-q-registry/releases/tag/v0.3.1
 [0.3.2]: https://github.com/westerveltco/django-q-registry/releases/tag/v0.3.2
 [0.4.0]: https://github.com/westerveltco/django-q-registry/releases/tag/v0.4.0
+[0.5.0]: https://github.com/westerveltco/django-q-registry/releases/tag/v0.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ Source = "https://github.com/westerveltco/django-q-registry"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.4.0"
+current_version = "0.5.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_q_registry/__init__.py
+++ b/src/django_q_registry/__init__.py
@@ -6,4 +6,4 @@ __all__ = [
     "register_task",
 ]
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_q_registry import __version__
 
 
 def test_version():
-    assert __version__ == "0.4.0"
+    assert __version__ == "0.5.0"


### PR DESCRIPTION
- `42f0912`: :robot: [pre-commit.ci] pre-commit autoupdate (#55)
- `7680c70`: :pencil: Spacing changes for docs project (#56)
- `d271afa`: [pre-commit.ci] pre-commit autoupdate (#58)
- `dfcac3b`: [pre-commit.ci] pre-commit autoupdate (#59)
- `7acc8c1`: :robot: [pre-commit.ci] pre-commit autoupdate (#60)
- `fd4d199`: [pre-commit.ci] pre-commit autoupdate (#61)
- `a2cf80f`: [pre-commit.ci] pre-commit autoupdate (#62)
- `02b28da`: [pre-commit.ci] pre-commit autoupdate (#63)
- `6b6a37d`: [pre-commit.ci] pre-commit autoupdate (#64)
- `ef70ea6`: [pre-commit.ci] pre-commit autoupdate (#65)
- `be70a61`: [pre-commit.ci] pre-commit autoupdate (#66)
- `6f7430e`: [pre-commit.ci] pre-commit autoupdate (#67)
- `cbc8311`: [pre-commit.ci] pre-commit autoupdate (#68)
- `dfe30c8`: [pre-commit.ci] pre-commit autoupdate (#69)
- `a36443b`: :robot: [pre-commit.ci] pre-commit autoupdate (#70)
- `b5de242`: :robot: [pre-commit.ci] pre-commit autoupdate (#71)
- `b8085b6`: [pre-commit.ci] pre-commit autoupdate (#72)
- `7342a9d`: [pre-commit.ci] pre-commit autoupdate (#73)
- `1a43d5a`: [pre-commit.ci] pre-commit autoupdate (#74)
- `05085f2`: :robot: [pre-commit.ci] pre-commit autoupdate (#75)
- `68f09b2`: [pre-commit.ci] pre-commit autoupdate (#76)
- `71120ea`: bump min Python version for `main` Django (#79)
- `0e7c7a9`: Drop Python 3.8 (#78)
- `1b2b93f`: update python versions in test workflow
- `bd428e3`: [pre-commit.ci] pre-commit autoupdate (#77)
- `30313dc`: add support for Django 5.1 (#80)
- `b29e02a`: add support for Django 5.2 (#81)