### PR TITLE
enable more ruff rule groups

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.18
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,9 +192,12 @@ fixable = ["A", "B", "C", "D", "E", "F", "I"]
 ignore = ["E501", "E741"]  # temporary
 select = [
   "B",  # flake8-bugbear
+  "DJ",  # flake8-django
   "E",  # Pycodestyle
   "F",  # Pyflakes
   "I",  # isort
+  "PT",  # flake8-pytest-style
+  "S",  # flake8-bandit
   "UP"  # pyupgrade
 ]
 unfixable = []

--- a/src/django_q_registry/models.py
+++ b/src/django_q_registry/models.py
@@ -194,6 +194,9 @@ class Task(models.Model):
 
     objects = TaskQuerySet.as_manager()
 
+    def __str__(self) -> str:
+        return self.name
+
     def __hash__(self) -> int:
         if self.pk is not None:
             return super().__hash__()


### PR DESCRIPTION
## Summary
- enable Ruff DJ, PT, and S rule groups
- switch pre-commit to the ruff-check hook
- add a __str__ method to Task for DJ008

## Tests
- uvx ruff check --statistics
- uvx ruff check
- uvx nox --session lint
- uvx nox --session "test" -- tests/test_models.py
- uvx nox --session "test"